### PR TITLE
Fix login for extended user models

### DIFF
--- a/src/schema/mutation/getRemoteMethodMutations.js
+++ b/src/schema/mutation/getRemoteMethodMutations.js
@@ -63,7 +63,7 @@ module.exports = function getRemoteMethodMutations(model) {
                                 });
 
                                 let ctxOptions;
-                                if(model.modelName == "user" && method.name == "login"){
+                                if( (model.name === "user" || model.ctor.base.name === "user") && method.name === "login"){
                                     ctxOptions = "";
                                 }else{
                                     ctxOptions = { accessToken: context.req.accessToken }


### PR DESCRIPTION
Making the dirty hack dirtier.

This allows for models that extend the base user class to still be able to use the login endpoint correctly.