### PR TITLE
FIXED #19: belongsTo relation returns null

### DIFF
--- a/src/db/index.js
+++ b/src/db/index.js
@@ -150,6 +150,7 @@ function findRelatedOne(rel, obj, args, context) {
     }
 
     args[rel.keyTo] = obj[rel.keyFrom]
+    if(args.id == undefined) args.id = obj[rel.keyFrom]
 
     return findOne(rel.modelTo, null, args, context);
 }


### PR DESCRIPTION
belongsTo relation returns null when keyTo not equal to 'id'